### PR TITLE
chore(deps): bump min node and homebridge versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "typescript": "^4.0.5"
       },
       "engines": {
-        "homebridge": ">=1.0.0",
-        "node": ">=10.17.0"
+        "homebridge": ">=1.2",
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -908,19 +908,6 @@
       "peerDependencies": {
         "commitizen": "^4.0.3",
         "inquirer": "^8.0.0"
-      }
-    },
-    "node_modules/@commitlint/cz-commitlint/node_modules/@commitlint/ensure": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-16.2.1.tgz",
-      "integrity": "sha512-/h+lBTgf1r5fhbDNHOViLuej38i3rZqTQnBTk+xEg+ehOwQDXUuissQ5GsYXXqI5uGy+261ew++sT4EA3uBJ+A==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^16.2.1",
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=v12"
       }
     },
     "node_modules/@commitlint/cz-commitlint/node_modules/@commitlint/execute-rule": {
@@ -14517,16 +14504,6 @@
         "word-wrap": "^1.2.3"
       },
       "dependencies": {
-        "@commitlint/ensure": {
-          "version": "16.2.1",
-          "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-16.2.1.tgz",
-          "integrity": "sha512-/h+lBTgf1r5fhbDNHOViLuej38i3rZqTQnBTk+xEg+ehOwQDXUuissQ5GsYXXqI5uGy+261ew++sT4EA3uBJ+A==",
-          "dev": true,
-          "requires": {
-            "@commitlint/types": "^16.2.1",
-            "lodash": "^4.17.19"
-          }
-        },
         "@commitlint/execute-rule": {
           "version": "16.2.1",
           "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-16.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/grivkees/homebridge-carrier-infinity/issues"
   },
   "engines": {
-    "node": ">=10.17.0",
-    "homebridge": ">=1.0.0"
+    "node": ">=12.13.0",
+    "homebridge": ">=1.2"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- min node version set to oldest LTS version
- min homebridge set to the version from when plugin was created, since
it hasn't been tested on anything older ever