### PR TITLE
fix(api): improve reliability of saves/pushes from HK to carrier API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "async-mutex": "^0.3.1",
         "axios": "^0.26.0",
         "oauth-signature": "^1.5.0",
+        "object-hash": "^2.2.0",
         "typescript-memoize": "^1.0.1",
         "xml2js": "^0.4.23"
       },
@@ -22,6 +23,7 @@
         "@semantic-release/git": "^10.0.1",
         "@types/jest": "^27.0.2",
         "@types/node": "^16.4.3",
+        "@types/object-hash": "^2.2.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
@@ -2341,6 +2343,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -11135,6 +11143,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -15685,6 +15701,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -22221,6 +22243,11 @@
           }
         }
       }
+    },
+    "object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "async-mutex": "^0.3.1",
     "axios": "^0.26.0",
     "oauth-signature": "^1.5.0",
+    "object-hash": "^2.2.0",
     "typescript-memoize": "^1.0.1",
     "xml2js": "^0.4.23"
   },
@@ -49,6 +50,7 @@
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.4.3",
+    "@types/object-hash": "^2.2.0",
     "@types/xml2js": "^0.4.8",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",


### PR DESCRIPTION
This batches changes to send to the api and hopefully helps with edge
cases where two changes made too close to each other can overwrite one
another. Hopefully helping with #147

It also makes the api more resiliant to how the caller calls the
methods, so we don't have to pass all zone args each time. This will
allow me to finish the refactor to unblock #111