### PR TITLE
fix(api): fix issue where api has a location with no systems listed

### DIFF
--- a/src/infinityApi.ts
+++ b/src/infinityApi.ts
@@ -255,7 +255,7 @@ export class InfinityEvolutionLocations extends BaseInfinityEvolutionApiModel {
     await this.fetch();
     const systems: string[] = [];
     for (const location of this.data_object.locations.location) {
-      for (const system of location.systems[0].system) {
+      for (const system of location.systems[0].system || []) {
         const link_parts = system['atom:link'][0]['$']['href'].split('/');
         systems.push(link_parts[link_parts.length - 1]);
       }


### PR DESCRIPTION
I think it may be possible for an account to have multiple locations, but have one empty. This probably would happen if someone moved their system between sites, but didn't delete the old site.

fix #310