### PR TITLE
feat: rewrite api to be observer based and poll/push updates to HomeKit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
           "ctype",
           "damperposition",
           "deadband",
+          "debounce",
           "Fanv",
           "filtrlvl",
           "featureset",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^0.27.2",
         "oauth-signature": "^1.5.0",
         "object-hash": "^3.0.0",
+        "rxjs": "^7.8.0",
         "typescript-memoize": "^1.1.1",
         "xml2js": "^0.4.23"
       },
@@ -11516,7 +11517,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
       "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -21852,7 +21852,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
       "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "axios": "^0.27.2",
     "oauth-signature": "^1.5.0",
     "object-hash": "^3.0.0",
+    "rxjs": "^7.8.0",
     "typescript-memoize": "^1.1.1",
     "xml2js": "^0.4.23"
   },

--- a/src/accessory_oat.ts
+++ b/src/accessory_oat.ts
@@ -2,7 +2,7 @@ import { CarrierInfinityHomebridgePlatform } from './platform';
 import { AccessoryInformation, CharacteristicWrapper, MultiWrapper } from './characteristics_base';
 import { convertSystemTemp2CharTemp } from './helpers';
 import { BaseAccessory } from './accessory_base';
-import { map, of, switchMap } from 'rxjs';
+import { map } from 'rxjs';
 
 class OATSensorTemp extends CharacteristicWrapper {
   ctype = this.Characteristic.CurrentTemperature;

--- a/src/accessory_oat.ts
+++ b/src/accessory_oat.ts
@@ -2,15 +2,14 @@ import { CarrierInfinityHomebridgePlatform } from './platform';
 import { AccessoryInformation, CharacteristicWrapper, MultiWrapper } from './characteristics_base';
 import { convertSystemTemp2CharTemp } from './helpers';
 import { BaseAccessory } from './accessory_base';
+import { map, of, switchMap } from 'rxjs';
 
 class OATSensorTemp extends CharacteristicWrapper {
   ctype = this.Characteristic.CurrentTemperature;
-  get = async () => {
-    return convertSystemTemp2CharTemp(
-      await this.system.status.getOutdoorTemp(),
-      'F', // The oat from the api is always in F (#97)
-    );
-  };
+  value = this.system.status.outdoor_temp.pipe(
+    // The oat from the api is always in F (#97)
+    map(x => convertSystemTemp2CharTemp(x, 'F')),
+  );
 }
 
 export class OutdoorTempSensorService extends MultiWrapper {

--- a/src/accessory_thermostat.ts
+++ b/src/accessory_thermostat.ts
@@ -26,14 +26,7 @@ export class ThermostatAccessory extends BaseAccessory {
     this.service = this.accessory.getService(
       this.platform.Service.Thermostat) || this.accessory.addService(this.platform.Service.Thermostat,
     );
-
-    // Create accessory api bridge
-    this.system.status.fetch().then();
-    this.system.config.fetch().then(async () => {
-      this.service.setCharacteristic(this.platform.Characteristic.Name, await this.system.config.getZoneName(this.accessory.context.zone));
-      // setting name explicitly is needed to not lose the word 'thermostat'
-      this.service.setCharacteristic(this.platform.Characteristic.Name, this.accessory.displayName);
-    });
+    this.service.setCharacteristic(this.platform.Characteristic.Name, this.context.name);
 
     // Accessory service handler
     new AccessoryInformation(
@@ -73,13 +66,10 @@ export class ThermostatAccessory extends BaseAccessory {
 
   setupFanService(): void {
     this.fan_service = this.fan_service || this.accessory.addService(this.platform.Service.Fanv2);
-
-    this.system.config.fetch().then(async () => {
-      this.fan_service?.setCharacteristic(
-        this.platform.Characteristic.Name,
-        await this.system.config.getZoneName(this.accessory.context.zone) + ' Fan',
-      );
-    });
+    this.fan_service.setCharacteristic(
+      this.platform.Characteristic.Name,
+      this.context.name.replace('Thermostat', 'Fan'), // TODO: this is a hack
+    );
 
     new FanService(
       this.platform,

--- a/src/accessory_thermostat.ts
+++ b/src/accessory_thermostat.ts
@@ -34,14 +34,6 @@ export class ThermostatAccessory extends BaseAccessory {
     this.system.status.fetch().then();
     this.system.config.fetch().then(async () => {
       this.service.setCharacteristic(this.platform.Characteristic.Name, await this.system.config.getZoneName(this.accessory.context.zone));
-      const temp_bounds = await this.system.config.getTempBounds();
-      const bound_props = {
-        minValue: Number(convertSystemTemp2CharTemp(temp_bounds[0], await this.system.config.getUnits())),
-        maxValue: Number(convertSystemTemp2CharTemp(temp_bounds[1], await this.system.config.getUnits())),
-      };
-      this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature).setProps(bound_props);
-      this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature).setProps(bound_props);
-      this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature).setProps(bound_props);
       // setting name explicitly is needed to not lose the word 'thermostat'
       this.service.setCharacteristic(this.platform.Characteristic.Name, this.accessory.displayName);
     });

--- a/src/accessory_thermostat.ts
+++ b/src/accessory_thermostat.ts
@@ -3,9 +3,6 @@ import { Service } from 'homebridge';
 import { CarrierInfinityHomebridgePlatform } from './platform';
 
 import { FilterService } from './characteristics_filter';
-import {
-  convertSystemTemp2CharTemp,
-} from './helpers';
 import { ThermostatRHService } from './characteristics_humidity';
 import { FanService } from './characteristics_fan';
 import { ACService } from './characteristics_ac';

--- a/src/accessory_thermostat.ts
+++ b/src/accessory_thermostat.ts
@@ -10,6 +10,7 @@ import { ThermostatRHService } from './characteristics_humidity';
 import { FanService } from './characteristics_fan';
 import { ACService } from './characteristics_ac';
 import { BaseAccessory } from './accessory_base';
+import { AccessoryInformation } from './characteristics_base';
 
 export class ThermostatAccessory extends BaseAccessory {
   private service: Service;
@@ -25,9 +26,6 @@ export class ThermostatAccessory extends BaseAccessory {
   ) {
     super(platform, context);
     // Create services
-    this.accessory.getService(this.platform.Service.AccessoryInformation)!
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.serialNumber);
-
     this.service = this.accessory.getService(
       this.platform.Service.Thermostat) || this.accessory.addService(this.platform.Service.Thermostat,
     );
@@ -47,11 +45,15 @@ export class ThermostatAccessory extends BaseAccessory {
       // setting name explicitly is needed to not lose the word 'thermostat'
       this.service.setCharacteristic(this.platform.Characteristic.Name, this.accessory.displayName);
     });
-    this.system.profile.fetch().then(async () => {
-      this.accessory.getService(this.platform.Service.AccessoryInformation)!
-        .setCharacteristic(this.platform.Characteristic.Manufacturer, `${await this.system.profile.getBrand()} Home`)
-        .setCharacteristic(this.platform.Characteristic.Model, await this.system.profile.getModel());
-    });
+
+    // Accessory service handler
+    new AccessoryInformation(
+      this.platform,
+      this.accessory.context,
+    ).wrap(
+      this.accessory.getService(this.platform.Service.AccessoryInformation) ||
+      this.accessory.addService(this.platform.Service.AccessoryInformation),
+    );
 
     // Create handlers
     new ACService(

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,9 +1,30 @@
-import {Zone as CZone} from './interface_config';
+import { ACTIVITY } from './constants';
+import Config, {Zone as CZone, Activity3 as CActivity} from './interface_config';
 import {Zone as SZone} from './interface_status';
 
 export function find_zone_by_id<T extends CZone | SZone>(data: T[], zone: string | number): T {
   // TODO: remove ! and add an error if zone out of bounds
   return data.find(
     (z) => z['$'].id === zone.toString(),
+  )!;
+}
+
+export function getZoneActivityConfig(data: Config, zone: string, activity_name: string): CActivity {
+  // Vacation is stored somewhere else...
+  if (activity_name === ACTIVITY.VACATION) {
+    return {
+      '$': {id: ACTIVITY.VACATION},
+      clsp: data.config.vacmaxt,
+      htsp: data.config.vacmint,
+      fan: data.config.vacfan,
+      previousFan: [],
+    };
+  }
+
+  const zone_obj = find_zone_by_id(data.config.zones[0].zone, zone);
+  const activities_obj = zone_obj.activities[0];
+  // TODO add assert valid zone name to remove !
+  return activities_obj['activity'].find(
+    (activity: CActivity) => activity['$'].id === activity_name,
   )!;
 }

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -2,7 +2,7 @@ import { ACTIVITY } from './constants';
 import Config, {Zone as CZone, Activity3 as CActivity} from './interface_config';
 import {Zone as SZone} from './interface_status';
 
-export function find_zone_by_id<T extends CZone | SZone>(data: T[], zone: string | number): T {
+export function findZoneByID<T extends CZone | SZone>(data: T[], zone: string | number): T {
   // TODO: remove ! and add an error if zone out of bounds
   return data.find(
     (z) => z['$'].id === zone.toString(),
@@ -21,7 +21,7 @@ export function getZoneActivityConfig(data: Config, zone: string, activity_name:
     };
   }
 
-  const zone_obj = find_zone_by_id(data.config.zones[0].zone, zone);
+  const zone_obj = findZoneByID(data.config.zones[0].zone, zone);
   const activities_obj = zone_obj.activities[0];
   // TODO add assert valid zone name to remove !
   return activities_obj['activity'].find(

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,0 +1,9 @@
+import {Zone as CZone} from './interface_config';
+import {Zone as SZone} from './interface_status';
+
+export function find_zone_by_id<T extends CZone | SZone>(data: T[], zone: string | number): T {
+  // TODO: remove ! and add an error if zone out of bounds
+  return data.find(
+    (z) => z['$'].id === zone.toString(),
+  )!;
+}

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -13,7 +13,7 @@ import Location from './interface_locations';
 import Profile from './interface_profile';
 import Status, {Zone as SZone} from './interface_status';
 import { ACTIVITY, FAN_MODE, SYSTEM_MODE, STATUS } from './constants';
-import { combineLatest, throttleTime, from, fromEvent, interval, merge, Observable, switchMap, of, distinctUntilChanged, mergeAll } from 'rxjs';
+import { combineLatest, throttleTime, from, fromEvent, interval, merge, Observable, switchMap, of, distinctUntilChanged, mergeAll, map } from 'rxjs';
 import EventEmitter from 'events';
 
 abstract class BaseModel {
@@ -152,31 +152,10 @@ export class SystemProfileModel extends BaseSystemModel {
     return `/systems/${this.serialNumber}/profile`;
   }
 
-  getName(): Observable<string> {
-    return this.data$.pipe(
-      switchMap(data => of(data.system_profile.name[0])),
-      // TODO do this with all?
-      distinctUntilChanged(),
-    );
-  }
-
-  getBrand(): Observable<string> {
-    return this.data$.pipe(
-      switchMap(data => of(data.system_profile.brand[0])),
-    );
-  }
-
-  getModel(): Observable<string> {
-    return this.data$.pipe(
-      switchMap(data => of(data.system_profile.model[0])),
-    );
-  }
-
-  getFirmware(): Observable<string> {
-    return this.data$.pipe(
-      switchMap(data => of(data.system_profile.firmware[0])),
-    );
-  }
+  public name = this.data$.pipe(map(data => data.system_profile.name[0]), distinctUntilChanged());
+  public brand = this.data$.pipe(map(data => data.system_profile.brand[0]), distinctUntilChanged());
+  public model = this.data$.pipe(map(data => data.system_profile.model[0]), distinctUntilChanged());
+  public firmware = this.data$.pipe(map(data => data.system_profile.firmware[0]), distinctUntilChanged());
 
   async getZones(): Promise<Array<string>> {
     await this.fetch();
@@ -196,20 +175,8 @@ export class SystemStatusModel extends BaseSystemModel {
     return `/systems/${this.serialNumber}/status`;
   }
 
-  async getUnits(): Promise<string> {
-    await this.fetch();
-    return this.data_object.status.cfgem[0];
-  }
-
-  async getOutdoorTemp(): Promise<number> {
-    await this.fetch();
-    return Number(this.data_object.status.oat[0]);
-  }
-
-  async getFilterUsed(): Promise<number> {
-    await this.fetch();
-    return Number(this.data_object.status.filtrlvl[0]);
-  }
+  public outdoor_temp = this.data$.pipe(map(data => Number(data.status.oat[0])), distinctUntilChanged());
+  public filter_used = this.data$.pipe(map(data => Number(data.status.filtrlvl[0])), distinctUntilChanged());
 
   async getMode(): Promise<string> {
     await this.fetch();

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -251,6 +251,7 @@ export class SystemStatusZoneModel {
   public activity = this.zone.pipe(map(zone => zone.currentActivity[0]), distinctUntilChanged());
   // The zone is blowing if the mode is on or the fan is on
   public blowing = combineLatest([this.mode, this.fan]).pipe(
+    debounceTime(50),
     map(([mode, fan]) => mode !== SYSTEM_MODE.OFF || fan !== FAN_MODE.OFF),
     distinctUntilChanged(),
   );
@@ -259,16 +260,19 @@ export class SystemStatusZoneModel {
   public closed = this.zone.pipe(map(zone => zone.damperposition[0] === '0'), distinctUntilChanged());
 
   public temp = combineLatest([this.zone, this.temp_units$]).pipe(
+    debounceTime(50),
     map(([zone, temp_units]) => [Number(zone.rt[0]), temp_units] as TempWithUnit),
     distinctUntilChanged(),
   );
 
   public cool_setpoint = combineLatest([this.zone, this.temp_units$]).pipe(
+    debounceTime(50),
     map(([zone, temp_units]) => [Number(zone.clsp[0]), temp_units] as TempWithUnit),
     distinctUntilChanged(),
   );
 
   public heat_setpoint = combineLatest([this.zone, this.temp_units$]).pipe(
+    debounceTime(50),
     map(([zone, temp_units]) => [Number(zone.htsp[0]), temp_units] as TempWithUnit),
     distinctUntilChanged(),
   );
@@ -655,22 +659,28 @@ export class SystemConfigZoneModel {
   private current_activity_config$ = combineLatest([
     this.zone,
     this.activity],
-  ).pipe(map(
-    ([zone, activity_name]) => {
-      return zone.activities[0].activity.find(
-        (a) => a['$'].id === activity_name,
-      )!;
-    },
-  ), distinctUntilChanged());
+  ).pipe(
+    debounceTime(50),
+    map(
+      ([zone, activity_name]) => {
+        return zone.activities[0].activity.find(
+          (a) => a['$'].id === activity_name,
+        )!;
+      },
+    ),
+    distinctUntilChanged(),
+  );
 
   public fan = this.current_activity_config$.pipe(map(activity => activity.fan[0]), distinctUntilChanged());
 
   public cool_setpoint = combineLatest([this.current_activity_config$, this.temp_units$]).pipe(
+    debounceTime(50),
     map(([activity, temp_units]) => [Number(activity.clsp[0]), temp_units] as TempWithUnit),
     distinctUntilChanged(),
   );
 
   public heat_setpoint = combineLatest([this.current_activity_config$, this.temp_units$]).pipe(
+    debounceTime(50),
     map(([activity, temp_units]) => [Number(activity.htsp[0]), temp_units] as TempWithUnit),
     distinctUntilChanged(),
   );
@@ -710,6 +720,7 @@ export class SystemModel {
       this.status.getZone(zone).activity,
       this.config.getZone(zone).activity,
     ]).pipe(
+      debounceTime(50),
       map(([s_activity, c_activity]) => {
         // Vacation scheduling is weird, and changes infrequently. Just get it from status.
         if (s_activity === ACTIVITY.VACATION) {

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -35,9 +35,7 @@ import EventEmitter from 'events';
 export type TempWithUnit = [number, string];
 
 abstract class BaseModel<T extends object> {
-  // protected data_object!: T; // TODO REMOVE
   public data$ = new ReplaySubject<T>(1);
-  // protected data_object_hash?: string;  // TODO REMOVE
   protected HASH_IGNORE_KEYS = new Set<string>();
   protected write_lock: Mutex;
   protected log: Logger = new PrefixLogger(this.infinity_client.log, 'API');
@@ -256,12 +254,6 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
     return `/systems/${this.serialNumber}/config`;
   }
 
-  // TODO: DELETE ME
-  async getUnits(): Promise<string> {
-    const data = await firstValueFrom(this.data$);
-    return data.config.cfgem[0];
-  }
-
   public mode = this.data$.pipe(map(data => data.config.mode[0]), distinctUntilChanged());
   public temp_units = this.data$.pipe(map(data => data.config.cfgem[0]), distinctUntilChanged());
   public temp_bounds = this.data$.pipe(map(data => [
@@ -279,16 +271,6 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
         (z) => z['$'].id === zone.toString(),
       )!,
     )), this.temp_units);
-  }
-
-  // TODO: DELETE ME
-  async getZoneName(zone: string): Promise<string> {
-    const data = await firstValueFrom(this.data$);
-    const zone_obj = data.config.zones[0].zone.find(
-      (z) => z['$'].id === zone.toString(),
-    )!;
-
-    return zone_obj['name'][0];
   }
 
   // TODO: DELETE ME
@@ -532,7 +514,7 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
     [htsp, clsp] = processSetpointDeadband(
       htsp || parseFloat(manual_activity_obj['htsp'][0]),
       clsp || parseFloat(manual_activity_obj['clsp'][0]),
-      await this.getUnits(),
+      await firstValueFrom(this.temp_units),
       // when setpoints are too close, make clsp sticky when no change made to htsp
       htsp === null,
     );

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -399,8 +399,8 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
       filter((new_clean_data) => dirty_hash === this.hash(new_clean_data)),
       take(1),
     ).subscribe({
-      next: () => {
-        this.log.info('Successful propagation to carrier api is confirmed.');
+      next: (data) => {
+        this.log.info(`Successful propagation to carrier api is confirmed for ${this.hash(data)}`);
         this.events.emit('onGet'); // TODO: pick different event
       },
       // As a fail-safe, revert to clean config if update failed

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -13,7 +13,20 @@ import Location from './interface_locations';
 import Profile from './interface_profile';
 import Status, {Zone as SZone} from './interface_status';
 import { ACTIVITY, FAN_MODE, SYSTEM_MODE, STATUS } from './constants';
-import { combineLatest, throttleTime, from, fromEvent, interval, merge, Observable, switchMap, of, distinctUntilChanged, mergeAll, map, filter, Subject } from 'rxjs';
+import {
+  combineLatest,
+  distinctUntilChanged,
+  from,
+  fromEvent,
+  interval,
+  map,
+  merge,
+  Observable,
+  of,
+  switchMap,
+  Subject,
+  throttleTime,
+} from 'rxjs';
 import EventEmitter from 'events';
 
 export type TempWithUnit = [number, string];

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -514,29 +514,26 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
     this.data$.next(data);
   }
 
-  // async setZoneActivityHold(
-  //   zone: string,
-  //   activity: string,
-  //   hold_until: string | null,
-  // ): Promise<void> {
-  //   this.mutations.push(async () => {
-  //     await this.mutateZoneActivityHold(zone, activity, hold_until);
-  //   });
-  //   // Schedule the push event, but don't wait for it to return.
-  //   this.push();
-  // }
+  async setZoneActivityHold(
+    zone: string,
+    activity: string,
+    hold_until: string | null,
+  ): Promise<void> {
+    this.log.debug(`Setting zone ${zone} activity to ${activity} until ${hold_until}`);
 
-  // private async mutateZoneActivityHold(
-  //   zone: string,
-  //   activity: string,
-  //   hold_until: string | null,
-  // ): Promise<void> {
-  //   this.log.debug(`Setting zone ${zone} activity to ${activity} until ${hold_until}`);
-  //   const zone_obj = await this.getZone(zone);
-  //   zone_obj['holdActivity']![0] = activity;
-  //   zone_obj['hold'][0] = activity ? STATUS.ON : STATUS.OFF;
-  //   zone_obj['otmr'][0] = activity ? hold_until || '' : '';
-  // }
+    // Get data from zone object and make changes
+    const data = await firstValueFrom(this.data$);
+    const zone_obj = data.config.zones[0].zone.find(
+      (z) => z['$'].id === zone.toString(),
+    )!;
+    zone_obj['holdActivity']![0] = activity;
+    zone_obj['hold'][0] = activity ? STATUS.ON : STATUS.OFF;
+    zone_obj['otmr'][0] = activity ? hold_until || '' : '';
+
+    // Push changes
+    this.last_pushed_ts = Date.now() + 10 * 1000;  // set to future to stop fetch
+    this.data$.next(data);
+  }
 
   // async setZoneActivityManualHold(
   //   zone: string,

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -473,12 +473,15 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
   ): Promise<void> {
     // Get data from zone / activity
     const data = await firstValueFrom(this.data$);
+    const zone_obj = findZoneByID(data.config.zones[0].zone, zone);
     const manual_activity_obj = getZoneActivityConfig(data, zone, ACTIVITY.MANUAL);
 
-    // Modify MANUAL activity to match current activity
+    // Modify MANUAL activity to match current activity, but only if we have
+    // not already made the switch to manual.
     if (
       sync_from_activity_name &&
-      sync_from_activity_name !== ACTIVITY.MANUAL
+      sync_from_activity_name !== ACTIVITY.MANUAL &&
+      zone_obj.holdActivity[0] !== ACTIVITY.MANUAL
     ) {
       const prev_activity_obj = getZoneActivityConfig(
         data,
@@ -488,10 +491,10 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
       manual_activity_obj['clsp'][0] = prev_activity_obj['clsp'][0];
       manual_activity_obj['htsp'][0] = prev_activity_obj['htsp'][0];
       manual_activity_obj['fan'][0] = prev_activity_obj['fan'][0];
-    }
 
-    // Push changes
-    this.dirty_data$.next(data);
+      // Push changes
+      this.dirty_data$.next(data);
+    }
   }
 
   async setZoneActivityManualSetpoints(

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -47,6 +47,12 @@ abstract class BaseModel {
       switchMap(
         () => from(this.fetch().then(() => this.data_object)),
       ),
+      distinctUntilChanged((prev, cur) => {
+        return (
+          // TODO reuse excluded keys fxn from below
+          hash(prev) === hash(cur)
+        );
+      }),
     );
   }
 
@@ -149,6 +155,8 @@ export class SystemProfileModel extends BaseSystemModel {
   getName(): Observable<string> {
     return this.data$.pipe(
       switchMap(data => of(data.system_profile.name[0])),
+      // TODO do this with all?
+      distinctUntilChanged(),
     );
   }
 

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -36,7 +36,7 @@ import {
   timeout,
 } from 'rxjs';
 import EventEmitter from 'events';
-import { find_zone_by_id, getZoneActivityConfig } from './helpers';
+import { findZoneByID, getZoneActivityConfig } from './helpers';
 
 // TODO: change public to read only
 // TODO: make F to C rounding consistent for value deduping
@@ -220,7 +220,7 @@ export class SystemStatusModel extends BaseSystemModel<Status> {
     // TODO assert valid zone
     // TODO save SystemStatusZoneModel to dedup
     return new SystemStatusZoneModel(this.raw_zone_data$.pipe(map(
-      data => find_zone_by_id(data, zone),
+      data => findZoneByID(data, zone),
     )), this.temp_units);
   }
 }
@@ -346,7 +346,7 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
     // TODO assert valid zone
     // TODO save SystemConfigZoneModel to dedup
     return new SystemConfigZoneModel(this.raw_zone_data$.pipe(map(
-      data => find_zone_by_id(data, zone),
+      data => findZoneByID(data, zone),
     )), this.temp_units);
   }
 
@@ -455,7 +455,7 @@ export class SystemConfigModel extends BaseSystemModel<Config> {
 
     // Get data from zone object and make changes
     const data = await firstValueFrom(this.data$);
-    const zone_obj = find_zone_by_id(data.config.zones[0].zone, zone);
+    const zone_obj = findZoneByID(data.config.zones[0].zone, zone);
     zone_obj['holdActivity']![0] = activity;
     zone_obj['hold'][0] = activity ? STATUS.ON : STATUS.OFF;
     zone_obj['otmr'][0] = activity ? hold_until || '' : '';

--- a/src/characteristics_ac.ts
+++ b/src/characteristics_ac.ts
@@ -2,7 +2,7 @@ import { CharacteristicValue } from 'homebridge';
 import { ThermostatCharacteristicWrapper, MultiWrapper } from './characteristics_base';
 import { convertCharTemp2SystemTemp, convertSystemTemp2CharTemp } from './helpers';
 import { FAN_MODE, SYSTEM_MODE } from './api/constants';
-import { combineLatest, map } from 'rxjs';
+import { combineLatest, firstValueFrom, map } from 'rxjs';
 
 class CurrentACStatus extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentHeatingCoolingState;
@@ -41,28 +41,28 @@ class TargetACState extends ThermostatCharacteristicWrapper {
     }
   }));
 
-  // set = async (value: CharacteristicValue) => {
-  //   switch(value) {
-  //     case this.Characteristic.TargetHeatingCoolingState.OFF: {
-  //       // If manual fan is set, go to fan only mode
-  //       if (await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()) !== FAN_MODE.OFF) {
-  //         return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
-  //       // If no manual fan, go to full off
-  //       } else {
-  //         return await this.system.config.setMode(SYSTEM_MODE.OFF);
-  //       }
-  //     }
-  //     case this.Characteristic.TargetHeatingCoolingState.COOL:
-  //       return await this.system.config.setMode(SYSTEM_MODE.COOL);
-  //     case this.Characteristic.TargetHeatingCoolingState.HEAT:
-  //       return await this.system.config.setMode(SYSTEM_MODE.HEAT);
-  //     case this.Characteristic.TargetHeatingCoolingState.AUTO:
-  //       return await this.system.config.setMode(SYSTEM_MODE.AUTO);
-  //     default:
-  //       this.log.error(`Don't know how to set target state '${value}'. Report bug: https://bit.ly/3igbU7D`);
-  //       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
-  //   }
-  // };
+  set = async (value: CharacteristicValue) => {
+    switch(value) {
+      case this.Characteristic.TargetHeatingCoolingState.OFF: {
+        // If manual fan is set, go to fan only mode
+        if (await firstValueFrom(this.system.config.getZone(this.context.zone).fan) !== FAN_MODE.OFF) {
+          return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
+        // If no manual fan, go to full off
+        } else {
+          return await this.system.config.setMode(SYSTEM_MODE.OFF);
+        }
+      }
+      case this.Characteristic.TargetHeatingCoolingState.COOL:
+        return await this.system.config.setMode(SYSTEM_MODE.COOL);
+      case this.Characteristic.TargetHeatingCoolingState.HEAT:
+        return await this.system.config.setMode(SYSTEM_MODE.HEAT);
+      case this.Characteristic.TargetHeatingCoolingState.AUTO:
+        return await this.system.config.setMode(SYSTEM_MODE.AUTO);
+      default:
+        this.log.error(`Don't know how to set target state '${value}'. Report bug: https://bit.ly/3igbU7D`);
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
+    }
+  };
 }
 
 class DisplayUnits extends ThermostatCharacteristicWrapper {

--- a/src/characteristics_ac.ts
+++ b/src/characteristics_ac.ts
@@ -2,12 +2,12 @@ import { CharacteristicValue } from 'homebridge';
 import { ThermostatCharacteristicWrapper, MultiWrapper } from './characteristics_base';
 import { convertCharTemp2SystemTemp, convertSystemTemp2CharTemp } from './helpers';
 import { FAN_MODE, SYSTEM_MODE } from './api/constants';
+import { combineLatest, map } from 'rxjs';
 
 class CurrentACStatus extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentHeatingCoolingState;
-  get = async () => {
-    const current_state = await this.system.status.getZoneConditioning(this.context.zone);
-    switch(current_state) {
+  value = this.system.status.getZone(this.context.zone).mode.pipe(map(data => {
+    switch(data) {
       case SYSTEM_MODE.OFF:
       case SYSTEM_MODE.FAN_ONLY:
         return this.Characteristic.CurrentHeatingCoolingState.OFF;
@@ -16,17 +16,16 @@ class CurrentACStatus extends ThermostatCharacteristicWrapper {
       case SYSTEM_MODE.HEAT:
         return this.Characteristic.CurrentHeatingCoolingState.HEAT;
       default:
-        this.log.error(`Unknown current state '${current_state}'. Report bug: https://bit.ly/3igbU7D`);
+        this.log.error(`Unknown current state '${data}'. Report bug: https://bit.ly/3igbU7D`);
         return this.Characteristic.CurrentHeatingCoolingState.OFF;
     }
-  };
+  }));
 }
 
 class TargetACState extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.TargetHeatingCoolingState;
-  get = async () => {
-    const target_state = await this.system.config.getMode();
-    switch(target_state) {
+  value = this.system.config.mode.pipe(map(data => {
+    switch(data) {
       case SYSTEM_MODE.OFF:
       case SYSTEM_MODE.FAN_ONLY:
         return this.Characteristic.TargetHeatingCoolingState.OFF;
@@ -37,92 +36,97 @@ class TargetACState extends ThermostatCharacteristicWrapper {
       case SYSTEM_MODE.AUTO:
         return this.Characteristic.TargetHeatingCoolingState.AUTO;
       default:
-        this.log.error(`Unknown target state '${target_state}'. Report bug: https://bit.ly/3igbU7D`);
+        this.log.error(`Unknown target state '${data}'. Report bug: https://bit.ly/3igbU7D`);
         return this.Characteristic.TargetHeatingCoolingState.OFF;
     }
-  };
+  }));
 
-  set = async (value: CharacteristicValue) => {
-    switch(value) {
-      case this.Characteristic.TargetHeatingCoolingState.OFF: {
-        // If manual fan is set, go to fan only mode
-        if (await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()) !== FAN_MODE.OFF) {
-          return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
-        // If no manual fan, go to full off
-        } else {
-          return await this.system.config.setMode(SYSTEM_MODE.OFF);
-        }
-      }
-      case this.Characteristic.TargetHeatingCoolingState.COOL:
-        return await this.system.config.setMode(SYSTEM_MODE.COOL);
-      case this.Characteristic.TargetHeatingCoolingState.HEAT:
-        return await this.system.config.setMode(SYSTEM_MODE.HEAT);
-      case this.Characteristic.TargetHeatingCoolingState.AUTO:
-        return await this.system.config.setMode(SYSTEM_MODE.AUTO);
-      default:
-        this.log.error(`Don't know how to set target state '${value}'. Report bug: https://bit.ly/3igbU7D`);
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
-    }
-  };
+  // set = async (value: CharacteristicValue) => {
+  //   switch(value) {
+  //     case this.Characteristic.TargetHeatingCoolingState.OFF: {
+  //       // If manual fan is set, go to fan only mode
+  //       if (await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()) !== FAN_MODE.OFF) {
+  //         return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
+  //       // If no manual fan, go to full off
+  //       } else {
+  //         return await this.system.config.setMode(SYSTEM_MODE.OFF);
+  //       }
+  //     }
+  //     case this.Characteristic.TargetHeatingCoolingState.COOL:
+  //       return await this.system.config.setMode(SYSTEM_MODE.COOL);
+  //     case this.Characteristic.TargetHeatingCoolingState.HEAT:
+  //       return await this.system.config.setMode(SYSTEM_MODE.HEAT);
+  //     case this.Characteristic.TargetHeatingCoolingState.AUTO:
+  //       return await this.system.config.setMode(SYSTEM_MODE.AUTO);
+  //     default:
+  //       this.log.error(`Don't know how to set target state '${value}'. Report bug: https://bit.ly/3igbU7D`);
+  //       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
+  //   }
+  // };
 }
 
 class DisplayUnits extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.TemperatureDisplayUnits;
-  get = async () => {
-    return await this.system.config.getUnits() === 'F' ?
+  value = this.system.config.temp_units.pipe(map(
+    data => data === 'F' ?
       this.Characteristic.TemperatureDisplayUnits.FAHRENHEIT :
-      this.Characteristic.TemperatureDisplayUnits.CELSIUS;
-  };
+      this.Characteristic.TemperatureDisplayUnits.CELSIUS),
+  );
 }
 
 class CurrentTemp extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentTemperature;
-  get = async () => {
-    return convertSystemTemp2CharTemp(
-      await this.system.status.getZoneTemp(this.context.zone),
-      await this.system.config.getUnits(),
-    );
-  };
+  value = this.system.status.getZone(this.context.zone).temp.pipe(map(
+    ([temp, temp_unit]) => convertSystemTemp2CharTemp(temp, temp_unit),
+  ));
 }
 
 class CoolSetpoint extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CoolingThresholdTemperature;
-  get = async () => {
-    return convertSystemTemp2CharTemp(
-      await this.system.config.getZoneActivityCoolSetpoint(this.context.zone, await this.getActivity()),
-      await this.system.config.getUnits(),
-    );
-  };
+  props = this.system.config.temp_bounds.pipe(map(data => {
+    return {
+      minValue: Number(convertSystemTemp2CharTemp(data[0][0], data[0][1])),
+      maxValue: Number(convertSystemTemp2CharTemp(data[1][0], data[1][1])),
+    };
+  }));
 
-  set = async (value: CharacteristicValue) => {
-    return await this.system.config.setZoneActivityManualHold(
-      this.context.zone,
-      convertCharTemp2SystemTemp(value, await this.system.config.getUnits()),
-      null,
-      await this.getHoldTime(),
-    );
-  };
+  value = this.system.config.getZone(this.context.zone).cool_setpoint.pipe(map(
+    ([temp, temp_unit]) => convertSystemTemp2CharTemp(temp, temp_unit),
+  ));
+
+  // set = async (value: CharacteristicValue) => {
+  //   return await this.system.config.setZoneActivityManualHold(
+  //     this.context.zone,
+  //     convertCharTemp2SystemTemp(value, await this.system.config.getUnits()),
+  //     null,
+  //     await this.getHoldTime(),
+  //   );
+  // };
 }
 
 class HeatSetpoint extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.HeatingThresholdTemperature;
   default_value = 10;
+  props = this.system.config.temp_bounds.pipe(map(data => {
+    return {
+      minValue: Number(convertSystemTemp2CharTemp(data[0][0], data[0][1])),
+      maxValue: Number(convertSystemTemp2CharTemp(data[1][0], data[1][1])),
+    };
+  }));
 
-  get = async () => {
-    return convertSystemTemp2CharTemp(
-      await this.system.config.getZoneActivityHeatSetpoint(this.context.zone, await this.getActivity()),
-      await this.system.config.getUnits(),
-    );
-  };
+  value = this.system.config.getZone(this.context.zone).heat_setpoint.pipe(map(
+    ([temp, temp_unit]) => convertSystemTemp2CharTemp(temp, temp_unit),
+  ));
 
-  set = async (value: CharacteristicValue) => {
-    return await this.system.config.setZoneActivityManualHold(
-      this.context.zone,
-      null,
-      convertCharTemp2SystemTemp(value, await this.system.config.getUnits()),
-      await this.getHoldTime(),
-    );
-  };
+
+  // set = async (value: CharacteristicValue) => {
+  //   return await this.system.config.setZoneActivityManualHold(
+  //     this.context.zone,
+  //     null,
+  //     convertCharTemp2SystemTemp(value, await this.system.config.getUnits()),
+  //     await this.getHoldTime(),
+  //   );
+  // };
 }
 
 class GeneralSetpoint extends ThermostatCharacteristicWrapper {
@@ -131,57 +135,57 @@ class GeneralSetpoint extends ThermostatCharacteristicWrapper {
    * system mode (i.e. heat or cool, not auto).
    */
   ctype = this.Characteristic.TargetTemperature;
-  get = async () => {
-    const mode = await this.system.config.getMode();
-    const activity = await this.getActivity();
-    switch (mode) {
-      case SYSTEM_MODE.COOL:
-        return convertSystemTemp2CharTemp(
-          await this.system.config.getZoneActivityCoolSetpoint(this.context.zone, activity),
-          await this.system.config.getUnits(),
-        );
-      case SYSTEM_MODE.HEAT:
-        return convertSystemTemp2CharTemp(
-          await this.system.config.getZoneActivityHeatSetpoint(this.context.zone, activity),
-          await this.system.config.getUnits(),
-        );
-      default:
-        return convertSystemTemp2CharTemp(
-          (
-            await this.system.config.getZoneActivityCoolSetpoint(this.context.zone, activity) +
-            await this.system.config.getZoneActivityHeatSetpoint(this.context.zone, activity)
-          ) / 2,
-          await this.system.config.getUnits(),
-        );
-    }
-  };
+  props = this.system.config.temp_bounds.pipe(map(data => {
+    return {
+      minValue: Number(convertSystemTemp2CharTemp(data[0][0], data[0][1])),
+      maxValue: Number(convertSystemTemp2CharTemp(data[1][0], data[1][1])),
+    };
+  }));
 
-  set = async (value: CharacteristicValue) => {
-    const svalue = convertCharTemp2SystemTemp(value, await this.system.config.getUnits());
-    const mode = await this.system.config.getMode();
-    switch (mode) {
+  value = combineLatest([
+    this.system.config.mode,
+    this.system.config.getZone(this.context.zone).cool_setpoint,
+    this.system.config.getZone(this.context.zone).heat_setpoint,
+  ]).pipe(map(([c_mode, c_cool_setpoint, c_heat_setpoint]) => {
+    switch (c_mode) {
       case SYSTEM_MODE.COOL:
-        return await this.system.config.setZoneActivityManualHold(
-          this.context.zone,
-          svalue,
-          null,
-          await this.getHoldTime(),
-        );
+        return convertSystemTemp2CharTemp(c_cool_setpoint[0], c_cool_setpoint[1]);
       case SYSTEM_MODE.HEAT:
-        return await this.system.config.setZoneActivityManualHold(
-          this.context.zone,
-          null,
-          svalue,
-          await this.getHoldTime(),
-        );
-      case SYSTEM_MODE.AUTO:
-        // For auto mode, Cool/Heat setpoints are used
-        return;
+        return convertSystemTemp2CharTemp(c_heat_setpoint[0], c_heat_setpoint[1]);
       default:
-        this.log.error(`Don't know how to set target temp for mode '${mode}'. Report bug: https://bit.ly/3igbU7D`);
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
+        return convertSystemTemp2CharTemp(
+          (c_cool_setpoint[0] + c_heat_setpoint[0]) / 2,
+          c_cool_setpoint[1],
+        );
     }
-  };
+  }));
+
+  // set = async (value: CharacteristicValue) => {
+  //   const svalue = convertCharTemp2SystemTemp(value, await this.system.config.getUnits());
+  //   const mode = await this.system.config.getMode();
+  //   switch (mode) {
+  //     case SYSTEM_MODE.COOL:
+  //       return await this.system.config.setZoneActivityManualHold(
+  //         this.context.zone,
+  //         svalue,
+  //         null,
+  //         await this.getHoldTime(),
+  //       );
+  //     case SYSTEM_MODE.HEAT:
+  //       return await this.system.config.setZoneActivityManualHold(
+  //         this.context.zone,
+  //         null,
+  //         svalue,
+  //         await this.getHoldTime(),
+  //       );
+  //     case SYSTEM_MODE.AUTO:
+  //       // For auto mode, Cool/Heat setpoints are used
+  //       return;
+  //     default:
+  //       this.log.error(`Don't know how to set target temp for mode '${mode}'. Report bug: https://bit.ly/3igbU7D`);
+  //       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
+  //   }
+  // };
 }
 
 export class ACService extends MultiWrapper {

--- a/src/characteristics_ac.ts
+++ b/src/characteristics_ac.ts
@@ -78,7 +78,7 @@ class CurrentTemp extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentTemperature;
   value = this.system.status.getZone(this.context.zone).temp.pipe(map(
     ([temp, temp_unit]) => {
-      this.log.warn(`glenlog: temp changed to ${temp}`); // TODO: REMOVE ME
+      this.log.warn(`Temp changed to ${temp}`); // TODO: REMOVE ME
       return convertSystemTemp2CharTemp(temp, temp_unit);
     },
   ));

--- a/src/characteristics_ac.ts
+++ b/src/characteristics_ac.ts
@@ -77,7 +77,10 @@ class DisplayUnits extends ThermostatCharacteristicWrapper {
 class CurrentTemp extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentTemperature;
   value = this.system.status.getZone(this.context.zone).temp.pipe(map(
-    ([temp, temp_unit]) => convertSystemTemp2CharTemp(temp, temp_unit),
+    ([temp, temp_unit]) => {
+      this.log.warn(`glenlog: temp changed to ${temp}`); // TODO: REMOVE ME
+      return convertSystemTemp2CharTemp(temp, temp_unit);
+    },
   ));
 }
 

--- a/src/characteristics_ac.ts
+++ b/src/characteristics_ac.ts
@@ -106,7 +106,6 @@ class CoolSetpoint extends ThermostatCharacteristicWrapper {
 
 class HeatSetpoint extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.HeatingThresholdTemperature;
-  default_value = 10;
   props = this.system.config.temp_bounds.pipe(map(data => {
     return {
       minValue: Number(convertSystemTemp2CharTemp(data[0][0], data[0][1])),

--- a/src/characteristics_base.ts
+++ b/src/characteristics_base.ts
@@ -97,27 +97,27 @@ export abstract class ThermostatCharacteristicWrapper extends CharacteristicWrap
   //   return await this.system.config.getZoneActivity(this.context.zone);
   // }
 
-  // async getHoldTime(): Promise<string> {
-  //   // OTMR setting to say when manual hold should end
-  //   switch (this.context.holdBehavior) {
-  //     case 'activity':
-  //       return await this.system.config.getZoneNextActivityTime(this.context.zone);
-  //     case 'for_x': {
-  //       const arg = this.context.holdArgument.split(':');
-  //       let target_ms = (new Date()).getTime();
-  //       target_ms += Number(arg[0]) * 60 * 60 * 1000;
-  //       target_ms += Number(arg[1]) * 60 * 1000;
-  //       const target_date = new Date(target_ms);
-  //       return `${target_date.getHours()}:${target_date.getMinutes()}`.padStart(5, '0');
-  //     }
-  //     case 'until_x':
-  //       return this.context.holdArgument;
-  //     case 'forever':
-  //       return '';
-  //     default:
-  //       return '';
-  //   }
-  // }
+  async getHoldTime(): Promise<string> {
+    // OTMR setting to say when manual hold should end
+    switch (this.context.holdBehavior) {
+      case 'activity':
+        return firstValueFrom(this.system.config.getZone(this.context.zone).next_activity_time);
+      case 'for_x': {
+        const arg = this.context.holdArgument.split(':');
+        let target_ms = (new Date()).getTime();
+        target_ms += Number(arg[0]) * 60 * 60 * 1000;
+        target_ms += Number(arg[1]) * 60 * 1000;
+        const target_date = new Date(target_ms);
+        return `${target_date.getHours()}:${target_date.getMinutes()}`.padStart(5, '0');
+      }
+      case 'until_x':
+        return this.context.holdArgument;
+      case 'forever':
+        return '';
+      default:
+        return '';
+    }
+  }
 }
 
 class AccessorySerial extends CharacteristicWrapper {

--- a/src/characteristics_base.ts
+++ b/src/characteristics_base.ts
@@ -1,4 +1,3 @@
-import { ACTIVITY } from './api/constants';
 import { SystemModel } from './api/models';
 import { Service, Characteristic, Logger } from 'homebridge';
 import { CharacteristicValue, UnknownContext, WithUUID } from 'homebridge';
@@ -58,7 +57,7 @@ export abstract class CharacteristicWrapper extends Wrapper {
     // Push updates from the system-based value observable to HK
     this.value.subscribe(
       async data => {
-        if (characteristic.value == data) {
+        if (characteristic.value === data) {
           this.log.warn(`BADPUSH Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
         } else {
           this.log.warn(`PUSH Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
@@ -73,7 +72,7 @@ export abstract class CharacteristicWrapper extends Wrapper {
       this.system.config.events.emit('onGet');
       // ... and return immediately the last seen api value.
       const data = await firstValueFrom(this.value);
-      if (characteristic.value != data) {
+      if (characteristic.value !== data) {
         this.log.warn(`GET Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
       }
       return data;

--- a/src/characteristics_base.ts
+++ b/src/characteristics_base.ts
@@ -58,7 +58,11 @@ export abstract class CharacteristicWrapper extends Wrapper {
     // Push updates from the system-based value observable to HK
     this.value.subscribe(
       async data => {
-        this.log.warn(`Updating ${this.ctype.name} to ${data}`); // TODO REMOVE
+        if (characteristic.value == data) {
+          this.log.warn(`BADPUSH Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
+        } else {
+          this.log.warn(`PUSH Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
+        }
         characteristic.updateValue(data);
       },
     );
@@ -69,8 +73,8 @@ export abstract class CharacteristicWrapper extends Wrapper {
       this.system.config.events.emit('onGet');
       // ... and return immediately the last seen api value.
       const data = await firstValueFrom(this.value);
-      if (characteristic.value !== data) {
-        this.log.warn(`Updating on GET ${this.ctype.name} to ${data}`); // TODO REMOVE
+      if (characteristic.value != data) {
+        this.log.warn(`GET Updating ${this.ctype.name} from ${characteristic.value} to ${data}`); // TODO REMOVE
       }
       return data;
     });

--- a/src/characteristics_base.ts
+++ b/src/characteristics_base.ts
@@ -6,10 +6,7 @@ import { CharacteristicValue, UnknownContext, WithUUID } from 'homebridge';
 import { CarrierInfinityHomebridgePlatform } from './platform';
 import { PrefixLogger } from './helper_logging';
 
-import Config from './api/interface_config';
-import Profile from './api/interface_profile';
-import Status from './api/interface_status';
-import { from, map, Observable, of, switchMap } from 'rxjs';
+import { map, Observable, of } from 'rxjs';
 /*
 * Helpers to add handlers to the HAP Service and Characteristic objects.
 */

--- a/src/characteristics_fan.ts
+++ b/src/characteristics_fan.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue } from 'homebridge';
 import { ThermostatCharacteristicWrapper, MultiWrapper } from './characteristics_base';
 import { convertCharFan2SystemFan, convertSystemFan2CharFan } from './helpers';
 import { FAN_MODE, SYSTEM_MODE } from './api/constants';
+import { combineLatest, map, of } from 'rxjs';
 
 /*
  * Controls for system fan.
@@ -22,140 +23,131 @@ import { FAN_MODE, SYSTEM_MODE } from './api/constants';
 
 class FanStatus extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.Active;
-  get = async () => {
-    if (
-      // if the system is configured to be off, the fan must be off
-      await this.system.config.getMode() === SYSTEM_MODE.OFF
-    ) {
+  value = combineLatest([
+    this.system.config.mode,
+    this.system.config.getZone(this.context.zone).fan,
+    this.system.status.getZone(this.context.zone).blowing,
+    this.system.status.getZone(this.context.zone).closed,
+  ]).pipe(map(([c_mode, c_fan, s_blowing, s_closed]) => {
+    // First, we do the absolute checks. If the status says blowing, or the system
+    // is shut off, we know the state.
+    if (s_blowing) {
+      return this.Characteristic.Active.ACTIVE;
+    } else if (c_mode === SYSTEM_MODE.OFF) {
       return this.Characteristic.Active.INACTIVE;
-    } else if (
-      // zone config api says manual fan mode
-      await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()) !== FAN_MODE.OFF ||
-      // zone status api says fan is on
-      await this.system.status.getZoneFan(this.context.zone) !== FAN_MODE.OFF ||
-      // zone status api says zone is conditioning
-      await this.system.status.getZoneConditioning(this.context.zone) !== SYSTEM_MODE.OFF
-    ) {
-      // but there is an exception to the above... which is the fan status/config
-      // can be wrong if the zone is actually closed off.
-      if (await this.system.status.getZoneOpen(this.context.zone)) {
-        return this.Characteristic.Active.ACTIVE;
-      } else {
-        return this.Characteristic.Active.INACTIVE;
-      }
-    } else {
-      return this.Characteristic.Active.INACTIVE;
+    // Second, we check for the edge case between when a user changes the state
+    // and the system picks it up. If the fan is set to on, the fan will be on
+    // soon, even though it isn't yet (which we know since blowing was false).
+    // This mitigates switch instability.
+    // However, we only do this edge case fix if the damper status is not closed,
+    // since if the damper reports it is closed, there is a good chance the
+    // config may be ignored for one reason or another. (#156)
+    } else if (c_fan !== FAN_MODE.OFF && !s_closed) {
+      return this.Characteristic.Active.ACTIVE;
     }
-  };
+    // Finally, if we get here the zone is not blowing.
+    return this.Characteristic.Active.INACTIVE;
+  }));
 
-  set = async (value: CharacteristicValue) => {
-    // if we are trying to *turn on* fan, and system is off, set to fan only mode
-    if (
-      value === this.Characteristic.Active.ACTIVE &&
-      await this.system.config.getMode() === SYSTEM_MODE.OFF
-    ) {
-      return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
-    }
+  // set = async (value: CharacteristicValue) => {
+  //   // if we are trying to *turn on* fan, and system is off, set to fan only mode
+  //   if (
+  //     value === this.Characteristic.Active.ACTIVE &&
+  //     await this.system.config.getMode() === SYSTEM_MODE.OFF
+  //   ) {
+  //     return await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
+  //   }
 
-    // if we are trying to turn off fan, turn off fan override (i.e. set fan speed=auto)
-    // NOTE: If system is in FAN_ONLY mode, it will remain in FAN ONLY, but with speed=auto.
-    if (value === this.Characteristic.Active.INACTIVE) {
-      return await this.system.config.setZoneActivityManualHold(
-        this.context.zone,
-        null,
-        null,
-        await this.getHoldTime(),
-        FAN_MODE.OFF,
-      );
-    }
-  };
+  //   // if we are trying to turn off fan, turn off fan override (i.e. set fan speed=auto)
+  //   // NOTE: If system is in FAN_ONLY mode, it will remain in FAN ONLY, but with speed=auto.
+  //   if (value === this.Characteristic.Active.INACTIVE) {
+  //     return await this.system.config.setZoneActivityManualHold(
+  //       this.context.zone,
+  //       null,
+  //       null,
+  //       await this.getHoldTime(),
+  //       FAN_MODE.OFF,
+  //     );
+  //   }
+  // };
 }
 
 class FanState extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.CurrentFanState;
-  get = async () => {
-    if (
-      // if the system is configured to be off, the fan must be off
-      await this.system.config.getMode() === SYSTEM_MODE.OFF
-    ) {
+  value = combineLatest([
+    this.system.config.mode,
+    this.system.config.getZone(this.context.zone).fan,
+    this.system.status.getZone(this.context.zone).blowing,
+    this.system.status.getZone(this.context.zone).closed,
+  ]).pipe(map(([c_mode, c_fan, s_blowing, s_closed]) => {
+    // First, we do the absolute checks. If the status says blowing, or the system
+    // is shut off, we know the state.
+    if (s_blowing) {
+      return this.Characteristic.CurrentFanState.BLOWING_AIR;
+    } else if (c_mode === SYSTEM_MODE.OFF) {
       return this.Characteristic.CurrentFanState.INACTIVE;
-    } else if (
-      // zone config api says manual fan mode
-      await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()) !== FAN_MODE.OFF ||
-      // zone status api says fan is on
-      await this.system.status.getZoneFan(this.context.zone) !== FAN_MODE.OFF ||
-      // zone status api says zone is conditioning
-      await this.system.status.getZoneConditioning(this.context.zone) !== SYSTEM_MODE.OFF
-    ) {
-      // but there is an exception to the above... which is the fan status/config
-      // can be wrong if the zone is actually closed off.
-      if (await this.system.status.getZoneOpen(this.context.zone)) {
-        return this.Characteristic.CurrentFanState.BLOWING_AIR;
-      } else {
-        return this.Characteristic.CurrentFanState.IDLE;
-      }
-    } else {
-      return this.Characteristic.CurrentFanState.IDLE;
+    // Second, we check for the edge case between when a user changes the state
+    // and the system picks it up. If the fan is set to on, the fan will be on
+    // soon, even though it isn't yet (which we know since blowing was false).
+    // This mitigates switch instability.
+    // However, we only do this edge case fix if the damper status is not closed,
+    // since if the damper reports it is closed, there is a good chance the
+    // config may be ignored for one reason or another. (#156)
+    } else if (c_fan !== FAN_MODE.OFF && !s_closed) {
+      return this.Characteristic.CurrentFanState.BLOWING_AIR;
     }
-  };
+    // Finally, if we get here the zone is not blowing.
+    return this.Characteristic.CurrentFanState.IDLE;
+  }));
 }
 
 class FanSpeed extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.RotationSpeed;
-  props = {minValue: 0, maxValue: 3, minStep: 1};
+  props = of({minValue: 0, maxValue: 3, minStep: 1});
+  value = this.system.config.getZone(this.context.zone).fan.pipe(map(data => convertSystemFan2CharFan(data)));
 
-  get = async () => {
-    return convertSystemFan2CharFan(
-      await this.system.config.getZoneActivityFan(this.context.zone, await this.getActivity()),
-    );
-  };
+  // set = async (value: CharacteristicValue) => {
+  //   // if we are trying to control fan, and system is off, set to fan only mode
+  //   if (await this.system.config.getMode() === SYSTEM_MODE.OFF) {
+  //     await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
+  //   }
 
-  set = async (value: CharacteristicValue) => {
-    // if we are trying to control fan, and system is off, set to fan only mode
-    if (await this.system.config.getMode() === SYSTEM_MODE.OFF) {
-      await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
-    }
-
-    // set fan speed
-    return await this.system.config.setZoneActivityManualHold(
-      this.context.zone,
-      null,
-      null,
-      await this.getHoldTime(),
-      convertCharFan2SystemFan(value),
-    );
-  };
+  //   // set fan speed
+  //   return await this.system.config.setZoneActivityManualHold(
+  //     this.context.zone,
+  //     null,
+  //     null,
+  //     await this.getHoldTime(),
+  //     convertCharFan2SystemFan(value),
+  //   );
+  // };
 }
 
 class TargetFanState extends ThermostatCharacteristicWrapper {
   ctype = this.Characteristic.TargetFanState;
-
-  get = async () => {
-    return await this.system.config.getZoneActivityFan(
-      this.context.zone,
-      await this.getActivity(),
-    ) === FAN_MODE.OFF ?
+  value = this.system.config.getZone(this.context.zone).fan.pipe(
+    map(data => data === FAN_MODE.OFF ?
       this.Characteristic.TargetFanState.AUTO :
-      this.Characteristic.TargetFanState.MANUAL;
-  };
+      this.Characteristic.TargetFanState.MANUAL),
+  );
 
-  set = async (value: CharacteristicValue) => {
-    // if we are trying to control fan, and system is off, set to fan only mode
-    if (await this.system.config.getMode() === SYSTEM_MODE.OFF) {
-      await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
-    }
+  // set = async (value: CharacteristicValue) => {
+  //   // if we are trying to control fan, and system is off, set to fan only mode
+  //   if (await this.system.config.getMode() === SYSTEM_MODE.OFF) {
+  //     await this.system.config.setMode(SYSTEM_MODE.FAN_ONLY);
+  //   }
 
-    // set fan speed to switch between auto and manual
-    return await this.system.config.setZoneActivityManualHold(
-      this.context.zone,
-      null,
-      null,
-      await this.getHoldTime(),
-      value === this.Characteristic.TargetFanState.AUTO ?
-        FAN_MODE.OFF :  // fan off is auto
-        FAN_MODE.MED, // moving to manual defaults to med
-    );
-  };
+  //   // set fan speed to switch between auto and manual
+  //   return await this.system.config.setZoneActivityManualHold(
+  //     this.context.zone,
+  //     null,
+  //     null,
+  //     await this.getHoldTime(),
+  //     value === this.Characteristic.TargetFanState.AUTO ?
+  //       FAN_MODE.OFF :  // fan off is auto
+  //       FAN_MODE.MED, // moving to manual defaults to med
+  //   );
+  // };
 }
 
 export class FanService extends MultiWrapper {

--- a/src/characteristics_filter.ts
+++ b/src/characteristics_filter.ts
@@ -1,4 +1,4 @@
-import { map, of, switchMap } from 'rxjs';
+import { map } from 'rxjs';
 import { CharacteristicWrapper, MultiWrapper } from './characteristics_base';
 
 class FilterLife extends CharacteristicWrapper {

--- a/src/characteristics_filter.ts
+++ b/src/characteristics_filter.ts
@@ -1,19 +1,18 @@
+import { map, of, switchMap } from 'rxjs';
 import { CharacteristicWrapper, MultiWrapper } from './characteristics_base';
 
 class FilterLife extends CharacteristicWrapper {
   ctype = this.Characteristic.FilterLifeLevel;
-  get = async () => {
-    return 100 - (await this.system.status.getFilterUsed());
-  };
+  value = this.system.status.filter_used.pipe(map(x => 100 - x));
 }
 
 class FilterChange extends CharacteristicWrapper {
   ctype = this.Characteristic.FilterChangeIndication;
-  get = async () => {
-    return (await this.system.status.getFilterUsed()) > 95 ?
+  value = this.system.status.filter_used.pipe(map(
+    x => x > 95 ?
       this.Characteristic.FilterChangeIndication.CHANGE_FILTER :
-      this.Characteristic.FilterChangeIndication.FILTER_OK;
-  };
+      this.Characteristic.FilterChangeIndication.FILTER_OK,
+  ));
 }
 
 export class FilterService extends MultiWrapper {

--- a/src/characteristics_humidity.ts
+++ b/src/characteristics_humidity.ts
@@ -2,9 +2,7 @@ import { CharacteristicWrapper, MultiWrapper } from './characteristics_base';
 
 class CurrentRH extends CharacteristicWrapper {
   ctype = this.Characteristic.CurrentRelativeHumidity;
-  get = async () => {
-    return await this.system.status.getZoneHumidity(this.context.zone);
-  };
+  value = this.system.status.getZone(this.context.zone).humidity;
 }
 
 class TargetDehumidify extends CharacteristicWrapper {

--- a/src/characteristics_humidity.ts
+++ b/src/characteristics_humidity.ts
@@ -5,13 +5,13 @@ class CurrentRH extends CharacteristicWrapper {
   value = this.system.status.getZone(this.context.zone).humidity;
 }
 
-class TargetDehumidify extends CharacteristicWrapper {
-  ctype = this.Characteristic.RelativeHumidityDehumidifierThreshold;
-}
+// class TargetDehumidify extends CharacteristicWrapper {
+//   ctype = this.Characteristic.RelativeHumidityDehumidifierThreshold;
+// }
 
-class TargetHumidify extends CharacteristicWrapper {
-  ctype = this.Characteristic.RelativeHumidityHumidifierThreshold;
-}
+// class TargetHumidify extends CharacteristicWrapper {
+//   ctype = this.Characteristic.RelativeHumidityHumidifierThreshold;
+// }
 
 
 export class ThermostatRHService extends MultiWrapper {
@@ -23,7 +23,7 @@ export class ThermostatRHService extends MultiWrapper {
 export class HumidifierService extends MultiWrapper {
   WRAPPERS = [
     CurrentRH,
-    TargetDehumidify,
-    TargetHumidify,
+    // TargetDehumidify,
+    // TargetHumidify,
   ];
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -42,6 +42,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
     this.api.on('didFinishLaunching', () => {
       this.discoverSystems().then().catch(error => {
         this.log.error('Could not discover devices: ' + error.message);
+        this.log.debug(error);
       });
     });
 
@@ -59,10 +60,11 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
   }
 
   async discoverSystems(): Promise<void> {
-    const systems = await new LocationsModel(this.infinity_client).getSystems();
+    const locations = await new LocationsModel(this.infinity_client);
+    const systems = await locations.getSystems();
     for (const serialNumber of systems) {
       // Create system api object, and save for later reference
-      const system = new SystemModel(this.infinity_client, serialNumber);
+      const system = await new SystemModel(this.infinity_client, serialNumber);
       this.systems[serialNumber] = system;
 
       // Add system based accessories

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -66,6 +66,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
     for (const serialNumber of systems) {
       // Create system api object, and save for later reference
       const system = await new SystemModel(this.infinity_client, serialNumber);
+      // TODO make sure we can fetch all api calls, and timeout if not.
       this.systems[serialNumber] = system;
 
       // Add system based accessories

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -11,6 +11,7 @@ import { EnvSensorAccessory } from './accessory_envsensor';
 import { BaseAccessory } from './accessory_base';
 import { ComfortActivityAccessory } from './accessory_comfort_activity';
 import { InfinityRestClient } from './api/rest_client';
+import { firstValueFrom } from 'rxjs';
 
 export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
@@ -61,7 +62,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
 
   async discoverSystems(): Promise<void> {
     const locations = await new LocationsModel(this.infinity_client);
-    const systems = await locations.getSystems();
+    const systems = await firstValueFrom(locations.system_serials);
     for (const serialNumber of systems) {
       // Create system api object, and save for later reference
       const system = await new SystemModel(this.infinity_client, serialNumber);
@@ -79,7 +80,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
       }
 
       // Add system+zone based accessories
-      const zones = await system.profile.getZones();
+      const zones = await firstValueFrom(system.profile.zone_ids);
       for (const zone of zones) {  // 'of' makes sure we go through zone ids, not index
         const context_zone = {...context_system, zone: zone};
         system.log.debug(`Discovered zone ${context_zone.zone}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -82,6 +82,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
       // Add system+zone based accessories
       const zones = await firstValueFrom(system.profile.zone_ids);
       for (const zone of zones) {  // 'of' makes sure we go through zone ids, not index
+        const zone_name = await firstValueFrom(system.config.getZone(zone).name);
         const context_zone = {...context_system, zone: zone};
         system.log.debug(`Discovered zone ${context_zone.zone}`);
         // -> Zone Accessory: Thermostat
@@ -89,7 +90,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
           this,
           {
             ...context_zone,
-            name: `${await system.config.getZoneName(zone)} Thermostat`,
+            name: `${zone_name} Thermostat`,
             holdBehavior: this.config['holdBehavior'],
             holdArgument: this.config['holdArgument'],
           },
@@ -100,7 +101,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
             this,
             {
               ...context_zone,
-              name: `${await system.config.getZoneName(zone)} Environmental Sensor`,
+              name: `${zone_name} Environmental Sensor`,
             },
           );
         }
@@ -110,7 +111,7 @@ export class CarrierInfinityHomebridgePlatform implements DynamicPlatformPlugin 
             this,
             {
               ...context_zone,
-              name: `${await system.config.getZoneName(zone)} Comfort Activity`,
+              name: `${zone_name} Comfort Activity`,
               holdBehavior: this.config['holdBehavior'],
               holdArgument: this.config['holdArgument'],
             },


### PR DESCRIPTION
This is a significant rewrite of the base carrier api away from promises and to observables. This allows the api data model to poll carrier for updates, and for those updates to automatically be pushed to HK.

This also changes the data push model to use the same, which simplifiers and hopefully makes it easier to remove edge cases in the set apis.

In my testing, these changes significantly improve the perceived responsiveness of the plugin.