### PR TITLE
fix(api): set default temp bounds when utility event is not set

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -278,8 +278,9 @@ export class SystemConfigModelReadOnly extends BaseSystemModel {
   }
 
   async getTempBounds(): Promise<[number, number]> {
+    // TODO: Utility event isn't always set. Find somewhere else to get this #543
     await this.fetch();
-    const utility_events = this.data_object.config.utilityEvent[0];
+    const utility_events = this.data_object.config.utilityEvent?.[0] || {'minLimit':['50'], 'maxLimit':['90']};
     return [Number(utility_events.minLimit[0]), Number(utility_events.maxLimit[0])];
   }
 


### PR DESCRIPTION
fixes #543

fixes #543