### PR TITLE
fix(thermostat): convert getTempBounds() output from °F to °C for Celsius users

### DIFF
--- a/src/accessory_thermostat.ts
+++ b/src/accessory_thermostat.ts
@@ -40,8 +40,8 @@ export class ThermostatAccessory extends BaseAccessory {
       this.service.setCharacteristic(this.platform.Characteristic.Name, await this.system.config.getZoneName(this.accessory.context.zone));
       const temp_bounds = await this.system.config.getTempBounds();
       const bound_props = {
-        minValue: Number(convertSystemTemp2CharTemp(temp_bounds[0], await this.system.config.getUnits())),
-        maxValue: Number(convertSystemTemp2CharTemp(temp_bounds[1], await this.system.config.getUnits())),
+        minValue: Number(convertSystemTemp2CharTemp(temp_bounds[0], 'F')),
+        maxValue: Number(convertSystemTemp2CharTemp(temp_bounds[1], 'F')),
       };
       safeSetProps(this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature), bound_props);
       safeSetProps(this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature), bound_props);


### PR DESCRIPTION
Closes #639

### Problem

Users with Celsius-configured systems get repeated HAP-NodeJS warnings on every poll cycle:

[homebridge-carrier-infinity] This plugin generated a warning from the characteristic 'Target Temperature': characteristic was supplied illegal value: number 12 exceeded minimum of 50.

`getTempBounds()` in `models_graphql.js` always returns `[50, 90]` hardcoded in °F. In `accessory_thermostat.ts` these bounds are passed through `convertSystemTemp2CharTemp()` using the system's `cfgem` unit. For Celsius users (`cfgem: 'C'`), `convertSystemTemp2CharTemp` returns the value unchanged (correctly assuming it's already °C), so HAP-NodeJS receives `minValue: 50` on a Celsius characteristic and rejects any normal Celsius setpoint below 50.

### Fix

Pass `'F'` explicitly when converting the bounds, since `getTempBounds()` always returns °F regardless of `cfgem`.

### Before
```ts
minValue: Number(convertSystemTemp2CharTemp(temp_bounds[0], await this.system.config.getUnits())),
maxValue: Number(convertSystemTemp2CharTemp(temp_bounds[1], await this.system.config.getUnits())),
```

### After
```ts
// getTempBounds() always returns °F regardless of cfgem, so convert explicitly from °F
minValue: Number(convertSystemTemp2CharTemp(temp_bounds[0], 'F')),
maxValue: Number(convertSystemTemp2CharTemp(temp_bounds[1], 'F')),
```

All 482 existing tests pass. Fahrenheit users are unaffected.