### PR TITLE
Okta token refresh failure logs full Axios error object, flooding Homebridge logs

### DIFF
--- a/src/api/graphql_client.ts
+++ b/src/api/graphql_client.ts
@@ -171,7 +171,7 @@ export class InfinityGraphQLClient {
         this.log.info('Completed login / token refresh successfully.');
         return;
       } catch (error) {
-        this.log.warn('Okta token refresh failed, falling back to assistedLogin:', error);
+        this.log.warn('Okta token refresh failed, falling back to assistedLogin:', error instanceof Error ? error.message : String(error));
         // Fall through to assistedLogin
       }
     }


### PR DESCRIPTION
Closes #642

### Describe the bug

When the Okta refresh token expires or is rejected by Carrier's SSO, the plugin logs the full Axios error object instead of just the error message. This produces 200+ line stack dumps in the Homebridge log every ~30 minutes, making the log effectively unusable — older entries are purged before they can be reviewed, and manual scrolling is nearly impossible.

### Log example

A single Okta refresh failure produces output like this:
[CarrierInfinity] Attempting login / token refresh.

[CarrierInfinity] Okta token refresh failed, falling back to assistedLogin: AxiosError: Request failed with status code 400

at settle (/var/lib/homebridge/node_modules/homebridge-carrier-infinity/node_modules/axios/lib/core/settle.js:19:12)

... (200+ more lines including full request/response objects, headers, socket details, etc.)

[CarrierInfinity] Completed login / token refresh successfully.

The fallback to `assistedLogin` works correctly every time — the verbose dump adds no actionable information.

### Root cause

In `src/api/graphql_client.ts`, the catch block logs the full error object:

```ts
this.log.warn('Okta token refresh failed, falling back to assistedLogin:', error);
```

Passing the raw `error` object to `log.warn` causes Node.js to serialize the entire Axios error including request config, response body, socket details, and stack trace.

### Fix

Log only `error.message` instead:

```ts
this.log.warn('Okta token refresh failed, falling back to assistedLogin:', error.message);
```

This produces a single compact line:
[CarrierInfinity] Okta token refresh failed, falling back to assistedLogin: Request failed with status code 400

Which is all the information needed — the fallback always succeeds anyway.

### Steps to reproduce

1. Run the plugin for 30+ minutes
2. Observe Homebridge logs when Okta refresh token expires
3. Note 200+ line error dump on every refresh cycle

### Expected behavior

A single log line noting the Okta failure and fallback, with no stack dump.

### Environment

- Plugin: `homebridge-carrier-infinity`
- Homebridge on Raspberry Pi 4
- Occurs regardless of temperature unit setting